### PR TITLE
fix: IconButton forwards `color` to IconWrapper

### DIFF
--- a/src/IconButton.tsx
+++ b/src/IconButton.tsx
@@ -49,7 +49,7 @@ export const IconButton: React.RefForwardingComponent<
         {...other}
       >
         <VisuallyHidden>{label}</VisuallyHidden>
-        <IconWrapper color="currentColor" size={size}>
+        <IconWrapper color={color} size={size}>
           {icon}
         </IconWrapper>
       </Button>


### PR DESCRIPTION
IconButton allows a `color` attribute in its API but doesn't use it. 
This commit forwards it to the IconWrapper so the icon correctly 
inherit the requested color.

Default is left as is (ie "currentColor") if no `color` is given.