### PR TITLE
Fix Props interfaces to be exported

### DIFF
--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -16,7 +16,7 @@ const sizes = () => ({
   xl: css({ width: "8.57rem", height: "8.57rem", fontSize: "3.70rem" })
 });
 
-interface AvatarProps {
+export interface AvatarProps {
   /** Determine the size of the avatar */
   size?: AvatarSizes;
   /** The image source */

--- a/src/Breadcrumbs.tsx
+++ b/src/Breadcrumbs.tsx
@@ -13,7 +13,7 @@ const hideScrollbar = css`
   }
 `;
 
-interface BreadcrumbsProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface BreadcrumbsProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: "md" | "lg";
   /** A list of BreadcrumbItem children */
   children:

--- a/src/Collapse.tsx
+++ b/src/Collapse.tsx
@@ -29,7 +29,7 @@ export function useCollapse(defaultShow: boolean = false) {
   };
 }
 
-interface CollapseProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface CollapseProps extends React.HTMLAttributes<HTMLDivElement> {
   /** A unique id required for accessibility purposes. */
   id: string;
   /** Controls whether the children should be visible */

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -14,7 +14,7 @@ export const useResponsiveContainerPadding = () => {
   });
 };
 
-type ContainerProps = React.HTMLAttributes<HTMLElement>;
+export type ContainerProps = React.HTMLAttributes<HTMLElement>;
 
 export const Container: React.FunctionComponent<ContainerProps> = (
   props: ContainerProps

--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { Alert } from "./Alert";
 import PropTypes from "prop-types";
 
-interface ErrorBoundaryProps {
+export interface ErrorBoundaryProps {
   /** The title of the error message. */
   title?: string;
   /** The subtitle of the error message. */

--- a/src/Layer.tsx
+++ b/src/Layer.tsx
@@ -7,7 +7,7 @@ import { useTheme } from "./Theme/Providers";
 
 export type LayerElevations = "xs" | "sm" | "md" | "lg" | "xl";
 
-interface LayerProps extends React.HTMLAttributes<HTMLElement> {
+export interface LayerProps extends React.HTMLAttributes<HTMLElement> {
   /** The size of the shadow to use */
   elevation?: LayerElevations;
   /** The contents of the layer */

--- a/src/Link.tsx
+++ b/src/Link.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import PropTypes from "prop-types";
 import { useTheme } from "./Theme/Providers";
 
-interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   /** The content of the link */
   children: React.ReactNode;
   /** Use a custom component. E.g., ReactRouter Link */

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -17,7 +17,7 @@ const KeyCodes = {
   End: 35
 };
 
-interface MenuListContextType {
+export interface MenuListContextType {
   focus: boolean;
   onKeyDown: (e: React.KeyboardEvent) => void;
 }

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -7,7 +7,7 @@ import { useHideBody } from "./Hooks/hide-body";
 import PropTypes from "prop-types";
 import { useTheme } from "./Theme/Providers";
 
-interface OverlayProps {
+export interface OverlayProps {
   /** Whether the overlay is open */
   isOpen: boolean;
   /** Whatever you'd like to appear on top */

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -18,7 +18,7 @@ import { mergeRefs } from "./Hooks/merge-refs";
 
 const AnimatedLayer = animated(Layer) as React.FunctionComponent<any>;
 
-interface PopoverProps {
+export interface PopoverProps {
   /** Whether the popover is currently open */
   isOpen?: boolean;
   /** The trigger of the popover */

--- a/src/Positions.tsx
+++ b/src/Positions.tsx
@@ -29,7 +29,7 @@ export type Placements =
   | "left"
   | "left-start";
 
-interface PositionsProps {
+export interface PositionerProps {
   /** Whether the item being positioned is visible */
   isOpen?: boolean;
   /** The placement of children */
@@ -45,7 +45,7 @@ interface PositionsProps {
   ) => React.ReactNode;
 }
 
-export const Positioner: React.FunctionComponent<PositionsProps> = ({
+export const Positioner: React.FunctionComponent<PositionerProps> = ({
   target,
   positionFixed,
   isOpen = true,

--- a/src/Sheet.tsx
+++ b/src/Sheet.tsx
@@ -112,7 +112,7 @@ const positions = (theme: Theme) => ({
 
 export type SheetPositions = "left" | "top" | "bottom" | "right";
 
-interface SheetProps {
+export interface SheetProps {
   /** Whether the sheet is visible */
   isOpen: boolean;
   /** A callback to handle closing the sheet */

--- a/src/Spinner.tsx
+++ b/src/Spinner.tsx
@@ -7,8 +7,8 @@ import { Text } from "./Text";
 import { useTheme } from "./Theme/Providers";
 
 const spin = keyframes`
-  to { 
-    transform: rotate(360deg); 
+  to {
+    transform: rotate(360deg);
   }
 `;
 
@@ -20,7 +20,7 @@ const sizeStyles = {
   xl: css({ width: "1.5rem", height: "1.5rem" })
 };
 
-interface SpinnerProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface SpinnerProps extends React.HTMLAttributes<HTMLDivElement> {
   /** The delay (in ms) before the spinner will appear */
   delay?: number;
   size?: "xs" | "sm" | "md" | "lg" | "xl";

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -21,7 +21,7 @@ const TableContext = React.createContext({ fixed: false });
  * A Table provides a useful abstraction for managing rows and columns.
  */
 
-interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
+export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
   /** An optional minimum width for table content. */
   minWidth?: string;
   /** An optional array of fixed layout widths for each column */

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -9,7 +9,7 @@ import { useTheme } from "./Theme/Providers";
  * It provides some basic horizontal padding and maintains responsive height.
  */
 
-interface ToolbarProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface ToolbarProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Reduce the height of the toolbar */
   compressed?: boolean;
 }


### PR DESCRIPTION
Hello, I want the `*Props` interfaces to be exported in order to extend the sancho's components like this:

```tsx
/** @jsx jsx */
import { jsx } from '@emotion/core';
import { Layer, LayerProps } from 'sancho';

interface DecoratedLayerProps extends LayerProps {
  backgroundColor: string;
}
export const DecoratedLayer: React.FC<DecoratedLayerProps> = props => {
  const { backgroundColor, ...restProps } = props;

  return (
    <Layer
      css={{
        backgroundColor,
      }}
      {...restProps}
    />
  );
};
```