### PR TITLE
Fix type definitions around React.forwardRef

### DIFF
--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -463,14 +463,15 @@ export interface ButtonProps
   [key: string]: any; // bad hack to permit component injection
 }
 
+interface Button extends React.ForwardRefExoticComponent<ButtonProps & React.RefAttributes<HTMLButtonElement>> {
+  propTypes?: React.WeakValidationMap<ButtonProps>;
+}
+
 /**
  * Your standard Button element
  */
 
-export const Button: React.RefForwardingComponent<
-  React.Ref<HTMLButtonElement>,
-  ButtonProps
-> = React.forwardRef(
+export const Button: Button = React.forwardRef(
   (
     {
       size = "md",
@@ -489,7 +490,7 @@ export const Button: React.RefForwardingComponent<
       onPress,
       ...other
     }: ButtonProps,
-    ref: React.Ref<any>
+    ref: React.Ref<HTMLButtonElement>
   ) => {
     const theme = useTheme();
     const isLink = other.to || other.href;

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -241,15 +241,16 @@ export interface InputBaseProps
   inputSize?: InputSize;
 }
 
+interface InputBase extends React.ForwardRefExoticComponent<InputBaseProps & React.RefAttributes<HTMLInputElement>> {
+  propTypes?: React.WeakValidationMap<InputBaseProps>;
+}
+
 /**
  * Our basic Input element. Use this when building customized
  * forms. Otherwise, stick with InputGroup
  */
 
-export const InputBase: React.RefForwardingComponent<
-  React.Ref<HTMLInputElement>,
-  InputBaseProps
-> = React.forwardRef(
+export const InputBase: InputBase = React.forwardRef(
   (
     { autoComplete, autoFocus, inputSize = "md", ...other }: InputBaseProps,
     ref: React.Ref<HTMLInputElement>

--- a/src/IconButton.tsx
+++ b/src/IconButton.tsx
@@ -17,14 +17,15 @@ export interface IconButtonProps extends Partial<ButtonProps> {
   children?: React.ReactNode;
 }
 
+interface IconButton extends React.ForwardRefExoticComponent<IconButtonProps & React.RefAttributes<HTMLButtonElement>> {
+  propTypes?: React.WeakValidationMap<IconButtonProps>;
+}
+
 /**
  * A component which composes Button and Icon to provide
  * interactive icon elements.
  */
-export const IconButton: React.RefForwardingComponent<
-  React.Ref<HTMLButtonElement>,
-  IconButtonProps
-> = React.forwardRef(
+export const IconButton: IconButton = React.forwardRef(
   (
     {
       label,

--- a/src/Layer.tsx
+++ b/src/Layer.tsx
@@ -14,10 +14,11 @@ export interface LayerProps extends React.HTMLAttributes<HTMLElement> {
   children: React.ReactNode;
 }
 
-export const Layer: React.RefForwardingComponent<
-  React.Ref<HTMLDivElement>,
-  LayerProps
-> = React.forwardRef(
+interface Layer extends React.ForwardRefExoticComponent<LayerProps & React.RefAttributes<HTMLDivElement>> {
+  propTypes?: React.WeakValidationMap<LayerProps>;
+}
+
+export const Layer: Layer = React.forwardRef(
   (
     { elevation = "md", children, ...other }: LayerProps,
     ref: React.Ref<HTMLDivElement>

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -16,10 +16,11 @@ export interface OverlayProps {
   onRequestClose: () => void;
 }
 
-export const Overlay: React.RefForwardingComponent<
-  React.Ref<HTMLDivElement>,
-  OverlayProps
-> = React.forwardRef(
+interface Overlay extends React.ForwardRefExoticComponent<OverlayProps & React.RefAttributes<HTMLDivElement>> {
+  propTypes?: React.WeakValidationMap<OverlayProps>;
+}
+
+export const Overlay: Overlay = React.forwardRef(
   (
     { isOpen, onRequestClose, children }: OverlayProps,
     ref: React.Ref<HTMLDivElement>

--- a/src/ScrollView.tsx
+++ b/src/ScrollView.tsx
@@ -22,6 +22,10 @@ export interface ScrollViewProps extends React.HTMLAttributes<HTMLDivElement> {
   innerRef?: React.RefObject<any>;
 }
 
+interface ScrollViewForward extends React.ForwardRefExoticComponent<ScrollViewProps & React.RefAttributes<ScrollViewHandles>> {
+  propTypes?: React.WeakValidationMap<ScrollViewProps>;
+}
+
 /**
  * A scroll view with some helpers, including:
  *  - smooth scrolling
@@ -30,20 +34,18 @@ export interface ScrollViewProps extends React.HTMLAttributes<HTMLDivElement> {
  * @param componentRef
  */
 
-const ScrollViewForward: React.RefForwardingComponent<
-  ScrollViewHandles,
-  ScrollViewProps
-> = (
-  {
-    overflowY,
-    children,
-    overflowX,
-    innerRef,
-    scrollAnimationConfig = { tension: 190, friction: 15, mass: 0.2 },
-    ...other
-  },
-  componentRef
-) => {
+const ScrollViewForward: ScrollViewForward = React.forwardRef<ScrollViewHandles, ScrollViewProps>(
+  (
+    {
+      overflowY,
+      children,
+      overflowX,
+      innerRef,
+      scrollAnimationConfig = { tension: 190, friction: 15, mass: 0.2 },
+      ...other
+    },
+    componentRef
+  ) => {
     const ref = React.useRef<HTMLDivElement>(null);
 
     /**
@@ -135,7 +137,8 @@ const ScrollViewForward: React.RefForwardingComponent<
         </div>
       </div>
     );
-  };
+  }
+);
 
 ScrollViewForward.propTypes = {
   overflowY: PropTypes.number,

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -299,14 +299,15 @@ export interface TabProps
   badge?: React.ReactNode | string | number;
 }
 
+interface Tab extends React.ForwardRefExoticComponent<TabProps & React.RefAttributes<HTMLButtonElement>> {
+  propTypes?: React.WeakValidationMap<TabProps>;
+}
+
 /**
  * A clickable tab item
  */
 
-export const Tab: React.RefForwardingComponent<
-  React.Ref<HTMLButtonElement>,
-  TabProps
-> = React.forwardRef(
+export const Tab: Tab = React.forwardRef(
   (
     {
       onParentSelect,

--- a/src/Theme/Providers.tsx
+++ b/src/Theme/Providers.tsx
@@ -67,10 +67,7 @@ export interface ColorModeProps {
   ref: React.Ref<any>;
 }
 
-const ColorMode: React.RefForwardingComponent<
-  React.Ref<any>,
-  ColorModeProps
-> = React.forwardRef(({ colors, children, ...other }: ColorModeProps, ref) => {
+const ColorMode = React.forwardRef<any, ColorModeProps>(({ colors, children, ...other }: ColorModeProps, ref) => {
   const theme = useTheme();
   // memo is necessary to prevent unnecessary rerenders
   // https://reactjs.org/docs/context.html#caveats
@@ -113,10 +110,7 @@ interface ModeProps {
   ref?: any;
 }
 
-export const LightMode: React.RefForwardingComponent<
-  React.Ref<any>,
-  ModeProps
-> = React.forwardRef(({ children, ...other }: ModeProps, ref) => {
+export const LightMode = React.forwardRef<any, ModeProps>(({ children, ...other }: ModeProps, ref) => {
   const theme = useTheme();
   return (
     <ColorMode colors={theme.modes.light} ref={ref} {...other}>
@@ -131,10 +125,7 @@ LightMode.displayName = "LightMode";
  * Provide a dark theme
  */
 
-export const DarkMode: React.RefForwardingComponent<
-  React.Ref<any>,
-  ModeProps
-> = React.forwardRef(({ children, ...other }: ModeProps, ref) => {
+export const DarkMode = React.forwardRef<any, ModeProps>(({ children, ...other }: ModeProps, ref) => {
   const theme = useTheme();
   return (
     <ColorMode colors={theme.modes.dark} ref={ref} {...other}>

--- a/src/Touchable.tsx
+++ b/src/Touchable.tsx
@@ -29,10 +29,7 @@ export interface TouchableProps {
   [key: string]: any; // lame hack to allow component injection
 }
 
-export const Touchable: React.RefForwardingComponent<
-  React.Ref<any>,
-  TouchableProps
-> = React.forwardRef(
+export const Touchable = React.forwardRef<any, TouchableProps>(
   (
     {
       children,


### PR DESCRIPTION
Hello,

`React.RefForwardingComponent<T, P>` is a type of **the argument** of `React.forwardRef()`, but not the return value.
`React.forwardRef()` returns a component of type `React.ForwardRefExoticComponent<P>`.