### PR TITLE
Fix typo in globals object on rollup.config.js

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,7 +33,7 @@ const plugins = [
 
 const globals = {
   react: "React",
-  "react-doc": "ReactDOM"
+  "react-dom": "ReactDOM"
 };
 
 export default [


### PR DESCRIPTION
A super small adjustment, but I think this should be `react-dom` 👍
