### PR TITLE
update typo in console error in useFocusTrap

### DIFF
--- a/src/Hooks/use-focus-trap.ts
+++ b/src/Hooks/use-focus-trap.ts
@@ -16,7 +16,7 @@ export function useFocusElement(
 
     function focusElement() {
       if (!elementRef.current) {
-        console.error("No element found to found");
+        console.error("No element found to focus");
         return;
       }
 


### PR DESCRIPTION
Super minor update, but I believe this should log "No element found to focus" 😅